### PR TITLE
docs: expand README with project details and language note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # Simon
-Juego de Simon Says para un proyecto de la universidad.
 
-Simon was an university project and is currently discontinued.
+A simple Simon Says game developed as a university project for the Texas Instruments Tiva C LaunchPad using the Energia IDE. It replicates the classic memory game where players repeat increasingly long sequences of lights.
+
+## Technologies Used
+- C++
+- Energia IDE
+- Texas Instruments Tiva C LaunchPad
+
+## Code Language
+The source code is written in Spanish as per class convention.
+
+## Archived Repository
+This repository has been archived and is no longer maintained.


### PR DESCRIPTION
## Summary
- document Simon Says university project and platform
- list C++, Energia IDE, and Tiva C LaunchPad under technologies
- clarify repository is archived and unmaintained
- note codebase is written in Spanish due to class convention

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68a09dffa6848321acba8266e5f85a6e